### PR TITLE
(GH-5) Make MarkdownlintProvider internal

### DIFF
--- a/src/Cake.Prca.Issues.Markdownlint.Tests/MarkdownlintProviderFixture.cs
+++ b/src/Cake.Prca.Issues.Markdownlint.Tests/MarkdownlintProviderFixture.cs
@@ -5,7 +5,7 @@
     using Core.Diagnostics;
     using Testing;
 
-    public class MarkdownlintProviderFixture
+    internal class MarkdownlintProviderFixture
     {
         public MarkdownlintProviderFixture(string fileResourceName)
         {

--- a/src/Cake.Prca.Issues.Markdownlint/MarkdownlintProvider.cs
+++ b/src/Cake.Prca.Issues.Markdownlint/MarkdownlintProvider.cs
@@ -9,7 +9,7 @@
     /// <summary>
     /// Provider for code analysis issues reported by Markdownlint.
     /// </summary>
-    public class MarkdownlintProvider : CodeAnalysisProvider
+    internal class MarkdownlintProvider : CodeAnalysisProvider
     {
         private readonly MarkdownlintSettings settings;
 


### PR DESCRIPTION
Make `MarkdownlintProvider` internal since it only should be called through the alias.

Fixes #5